### PR TITLE
impl: speed up prom-latency using pad-link-post & pad-unlink-post hooks to cache metrics on quark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.code-workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,9 @@ gobject-sys = "0.20"
 gstreamer         = { version = "0.23.6", features = ["v1_18"] }
 gstreamer-sys     = "0.23.6"  # raw FFI for hook registration
 
-[profile.release]
-lto = "thin"
-opt-level = 2
-debug = "limited"
-panic = 'unwind'
+[profile.profiling]
+inherits = "release"
+debug = true
 
 [profile.test]
 inherits = "dev"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
-# Gstreamer Prometheus Latency Tracer
+# Gstreamer Otel Tracers
 
-A GStreamer `Tracer` plugin that measures per-element pad buffer processing latency and exports these metrics in Prometheus format.
+A collection of GStreamer `Tracer` plugins that measures per-element pad buffer processing latency and exports these metrics in Prometheus format & Otel format.
 
-A rust reimagination of [gstlatency.c](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gstreamer/plugins/tracers/gstlatency.c) written by [Stefan Sauer](ensonic@users.sf.net), with additional features for Prometheus compatibility.
+A rust reimagination of [gstlatency.c](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gstreamer/plugins/tracers/gstlatency.c) written by [Stefan Sauer](ensonic@users.sf.net), with additional features for Prometheus & Otel compatibility.
+
+## Plugins available
+
+The table below contains the plugins available in this repository.
+
+| plugin name  | description                                                                                                               | performance  | stability |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------ | --------- |
+| prom-latency | captures per element latencies as prometheus metrics                                                                      | low overhead | alpha     |
+| otel-tracer  | captures per element latencies as otel traces, gst::logs as otel logs, and otel-compatiable metrics with full association | very slow    | pre-alpha |
+| noop-latency | a test plugin, likely not useful for any real purpose                                                                     | slow         | none      |
+
+> Currently, the way per element latency is calculated is confusing in that it captures all
+> latency between the measured element and the next thread boundary, such as a queue, or a sink element.
+>
+> A future change will address this issue to capture latency across the element in question only, but for now
+> prom-latency and otel-tracer serve more as a POC that this is possible.
 
 ## Setup
 
@@ -42,11 +58,20 @@ Alternatively, you can use the provided DevContainer setup. This requires Docker
 
 ## Building
 
+The plugins can be built with the command below:
+
 ```bash
 just build
 # or
 cargo build
+
+# individually build only the plugin(s) you want
+cargo build -p gst-prometheus-tracer
+# or
+cargo build -p gst-otel-tracer
 ```
+
+If using in production, building in release mode is recommended.
 
 ## Installation
 
@@ -152,9 +177,10 @@ just test
 cargo test
 ```
 
-## Future work
+## Ongoing work
 
-Would like to support otel in addition to prometheus.
+- [ ] Measure latency across elements individually rather than cumulatively across all following elements until next thread boundary or sink element
+- [ ] Port performance improvements to the otel plugin
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The table below contains the plugins available in this repository.
 
 | plugin name  | description                                                                                                               | performance  | stability |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------ | --------- |
-| prom-latency | captures per element latencies as prometheus metrics                                                                      | low overhead | alpha     |
+| prom-latency | captures per element latencies as prometheus metrics                                                                      | optimized    | alpha     |
 | otel-tracer  | captures per element latencies as otel traces, gst::logs as otel logs, and otel-compatiable metrics with full association | very slow    | pre-alpha |
 | noop-latency | a test plugin, likely not useful for any real purpose                                                                     | slow         | none      |
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,13 @@ cargo test
 
 ## Ongoing work
 
-- [ ] Measure latency across elements individually rather than cumulatively across all following elements until next thread boundary or sink element
-- [ ] Port performance improvements to the otel plugin
+- [x] Cache relationship information on `pad_link_post` and `pad_unlink_post` to minimize the `pad_push_pre` and `pad_push_post` look-up time.
+- [ ] Measure latency across elements individually rather than cumulatively across all following elements until next thread boundary or sink element.
+- [ ] Port performance improvements made to prom-latency to the otel plugin.
+- [ ] Support latency measurements across bin elements.
+- [ ] Split count metric into `buf_in_count` and `buf_out_count` to capture behavior of muxer & demuxer elements.
+- [ ] Better support latency measurements for elements and bins with multiple sink and src pads.
+- [ ] Reimplement `pad_pull_pre` and `pad_pull_post` hooks to properly capture latency (unsure exactly how this will look at this point).
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -56,9 +56,10 @@ test-ci:
 [group('perf')]
 bench-perf perf_opts="":
     mkdir -p target/bench/perf
+    cargo build --profile "profiling"
     # Find all test executables without running them and then profile each one.
     branch_name=$(git rev-parse --abbrev-ref HEAD); \
-    for test_executable in $(cargo test --no-run --message-format=json | jq -r 'select(.profile.test == true) | .filenames[]'); do \
+    for test_executable in $(cargo test --profile profiling --no-run --message-format=json | jq -r 'select(.profile.test == true) | .filenames[]'); do \
         for bench in $($test_executable --list | grep ::bench | awk -F'::' '{print $NF}' | awk -F':' '{print $1}' | sort -u); do \
           perf record {{perf_opts}} -o "target/bench/perf/$bench.$branch_name.data" $test_executable "$bench"; \
           perf report -i "target/bench/perf/$bench.$branch_name.data" >> "target/bench/perf/$bench.$branch_name.txt"; \

--- a/tracer/otel/tests/oteltracer.rs
+++ b/tracer/otel/tests/oteltracer.rs
@@ -45,10 +45,9 @@ mod tests {
         let root_manifest_dir = manifest_dir.parent().unwrap().parent().unwrap();
         let debug_plugin_path = root_manifest_dir.join("target/debug");
         let release_plugin_path = root_manifest_dir.join("target/release");
-        let debug_plugin_with_target =
-            debug_plugin_path.join(format!("{}-unknown-linux-gnu", ARCH));
+        let debug_plugin_with_target = debug_plugin_path.join(format!("{ARCH}-unknown-linux-gnu"));
         let release_plugin_with_target =
-            release_plugin_path.join(format!("{}-unknown-linux-gnu", ARCH));
+            release_plugin_path.join(format!("{ARCH}-unknown-linux-gnu"));
         env::set_var(
             "GST_PLUGIN_PATH",
             format!(
@@ -67,8 +66,7 @@ mod tests {
         assert!(
             gst::TracerFactory::factories()
                 .iter()
-                .find(|f| f.name() == "otel-tracer")
-                .is_some(),
+                .any(|f| f.name() == "otel-tracer"),
             "Expected to find the `otel-tracer` element after registration"
         );
 

--- a/tracer/prometheus/src/promlatency.rs
+++ b/tracer/prometheus/src/promlatency.rs
@@ -20,7 +20,6 @@ use std::sync::LazyLock;
 use std::sync::OnceLock;
 use std::thread;
 
-use dashmap::DashMap;
 use glib::subclass::prelude::*;
 use glib::translate::IntoGlib;
 use glib::Quark;
@@ -30,55 +29,75 @@ use gst::subclass::prelude::*;
 use gstreamer as gst;
 use lazy_static::lazy_static;
 use once_cell::sync::Lazy;
-use prometheus::{
-    gather, register_counter_vec, register_gauge_vec, Counter, CounterVec, Encoder, Gauge,
-    GaugeVec, TextEncoder,
-};
+use prometheus::{gather, Encoder, TextEncoder};
 use tiny_http::{Header, Response, Server};
 
-/// Guarantee we only start the server once, even if `plugin_init`
-/// gets called multiple times by GStreamer.
-static METRICS_SERVER_ONCE: OnceLock<()> = OnceLock::new();
-static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
-    gst::DebugCategory::new(
-        "prom-latency",
-        gst::DebugColorFlags::empty(),
-        Some("Prometheus tracer"),
-    )
-});
-
-// A global, concurrent cache mapping pad‐ptrs → (last, sum, count)
-static METRIC_CACHE: Lazy<DashMap<usize, (Gauge, Counter, Counter)>> = Lazy::new(DashMap::new);
-static LATENCY_QUARK: Lazy<u32> = Lazy::new(|| Quark::from_str("latency_probe.ts").into_glib());
-
-// Define Prometheus metrics, all in nanoseconds
-lazy_static! {
-    static ref LATENCY_LAST: GaugeVec = register_gauge_vec!(
-        "gst_element_latency_last_gauge",
-        "Last latency in nanoseconds per element",
-        &["element", "src_pad", "sink_pad"]
-    )
-    .unwrap();
-    static ref LATENCY_SUM: CounterVec = register_counter_vec!(
-        "gst_element_latency_sum_count",
-        "Sum of latencies in nanoseconds per element",
-        &["element", "src_pad", "sink_pad"]
-    )
-    .unwrap();
-    static ref LATENCY_COUNT: CounterVec = register_counter_vec!(
-        "gst_element_latency_count_count",
-        "Count of latency measurements per element",
-        &["element", "src_pad", "sink_pad"]
-    )
-    .unwrap();
-}
-
-// Our Tracer subclass
 mod imp {
     use std::os::raw::c_void;
 
     use super::*;
-    use glib::translate::ToGlibPtr;
+    use glib::{
+        ffi::{gboolean, GTRUE},
+        translate::ToGlibPtr,
+    };
+    use prometheus::{
+        register_int_counter_vec, register_int_gauge_vec, IntCounter, IntCounterVec, IntGauge,
+        IntGaugeVec,
+    };
+
+    // Define Prometheus metrics, all in nanoseconds
+    lazy_static! {
+        static ref LATENCY_LAST: IntGaugeVec = register_int_gauge_vec!(
+            "gst_element_latency_last_gauge",
+            "Last latency in nanoseconds per element",
+            &["element", "src_pad", "sink_pad"]
+        )
+        .unwrap();
+        static ref LATENCY_SUM: IntCounterVec = register_int_counter_vec!(
+            "gst_element_latency_sum_count",
+            "Sum of latencies in nanoseconds per element",
+            &["element", "src_pad", "sink_pad"]
+        )
+        .unwrap();
+        static ref LATENCY_COUNT: IntCounterVec = register_int_counter_vec!(
+            "gst_element_latency_count_count",
+            "Count of latency measurements per element",
+            &["element", "src_pad", "sink_pad"]
+        )
+        .unwrap();
+    }
+    static PAD_CACHE_QUARK: Lazy<glib::ffi::GQuark> =
+        Lazy::new(|| Quark::from_str("promlatency.pad_cache").into_glib());
+
+    static METRICS_SERVER_ONCE: OnceLock<()> = OnceLock::new();
+    static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+        gst::DebugCategory::new(
+            "prom-latency",
+            gst::DebugColorFlags::empty(),
+            Some("Prometheus tracer"),
+        )
+    });
+
+    /// This is used to cache the decision for a pad, so we don't have to
+    /// repeatedly check the pad's state.
+    /// If the value is null, it means we should skip measuring latency for this pad.
+    /// If the value is a valid pointer, we fetch the PadCacheData from it.
+    const PAD_SKIP_SENTINEL: *mut c_void = std::ptr::null_mut();
+
+    /// Data structure to hold cached pad information used for latency measurement.
+    struct PadCacheData {
+        /// The verdict tag indicating whether to skip or measure latency.
+        ts: u64, // timestamp of the last push/pull
+
+        /// Pointer to the peer pad, used during unlink to verify the pad pair.
+        peer: *mut c_void,
+
+        last_gauge: IntGauge,
+        sum_counter: IntCounter,
+        // TODO - at the moment we don't differentiate between buffers into the element vs buffers out, will require
+        //          a change to what we are doing here to make that work.
+        count_counter: IntCounter,
+    }
 
     #[derive(Default)]
     pub struct PromLatencyTracer;
@@ -105,19 +124,9 @@ mod imp {
                 _tracer: *mut gst::Tracer,
                 ts: u64,
                 pad: *mut gst::ffi::GstPad,
+                _buf_ptr: *mut gst::ffi::GstBuffer,
             ) {
-                let peer = ffi::gst_pad_get_peer(pad);
-                do_send_latency_ts(ts, pad, peer);
-            }
-
-            unsafe extern "C" fn do_pull_range_pre(
-                _tracer: *mut gst::Tracer,
-                ts: u64,
-                pad: *mut gst::ffi::GstPad,
-            ) {
-                // For pull, we treat sink as src, src as sink as we're going the other way
-                let peer = ffi::gst_pad_get_peer(pad);
-                do_send_latency_ts(ts, peer, pad);
+                do_send_latency_ts(ts, pad);
             }
 
             unsafe extern "C" fn do_push_buffer_post(
@@ -125,22 +134,100 @@ mod imp {
                 ts: u64,
                 pad: *mut gst::ffi::GstPad,
             ) {
-                // Calculate latency when buffer arrives at sink
-                let peer = ffi::gst_pad_get_peer(pad);
-                do_receive_and_record_latency_ts(ts, pad, peer);
+                do_receive_and_record_latency_ts(ts, pad);
             }
 
+            unsafe extern "C" fn do_pull_range_pre(
+                _tracer: *mut gst::Tracer,
+                _ts: u64,
+                _pad: *mut gst::ffi::GstPad,
+            ) {
+                // TODO - revisit pull, which requires us to be careful about how we traverse proxy and ghost pads.
+                // For pull, we treat sink as src, src as sink as we're going the other way
+                // let peer = ffi::gst_pad_get_peer(pad);
+                // do_send_latency_ts(ts, peer);
+            }
             unsafe extern "C" fn do_pull_range_post(
                 _tracer: *mut gst::Tracer,
-                ts: u64,
-                pad: *mut gst::ffi::GstPad,
+                _ts: u64,
+                _pad: *mut gst::ffi::GstPad,
             ) {
+                // TODO - revisit pull, which requires us to be careful about how we traverse proxy and ghost pads.
                 // For pull, we treat sink as src, src as sink as we're going the other way
-                let peer = ffi::gst_pad_get_peer(pad);
-                do_receive_and_record_latency_ts(ts, peer, pad);
+                // let peer = ffi::gst_pad_get_peer(pad);
+                // do_receive_and_record_latency_ts(ts, peer, pad);
+            }
+
+            unsafe extern "C" fn do_pad_link_post(
+                _tracer: *mut gst::Tracer,
+                _ts: u64,
+                src_pad: *mut gst::ffi::GstPad,
+                sink_pad: *mut gst::ffi::GstPad,
+                res: gst::ffi::GstPadLinkReturn,
+            ) {
+                if res == ffi::GST_PAD_LINK_OK {
+                    let pad_latency_cache = do_create_latency_cache_for_pad_pair(src_pad, sink_pad);
+                    if pad_latency_cache == PAD_SKIP_SENTINEL as *mut PadCacheData {
+                        gst::trace!(
+                            CAT,
+                            "do_pad_link_post called for src_pad: {:?}, sink_pad: {:?}, but no cache found.",
+                            src_pad,
+                            sink_pad
+                        );
+                        return;
+                    }
+
+                    // If we have a valid cache, we store it in the src_pad's quark data.
+                    glib::gobject_ffi::g_object_set_qdata_full(
+                        src_pad as *mut gobject_sys::GObject,
+                        *PAD_CACHE_QUARK,
+                        pad_latency_cache as *mut c_void,
+                        Some(drop_value::<PadCacheData>),
+                    );
+                }
+            }
+
+            unsafe extern "C" fn do_pad_unlink_post(
+                _tracer: *mut gst::Tracer,
+                _ts: u64,
+                src_pad: *mut gst::ffi::GstPad,
+                sink_pad: *mut gst::ffi::GstPad,
+                res: gboolean,
+            ) {
+                // For reasons unknown to me, this callback appears to be called a lot. Perhaps it is accidentally
+                // registering for all events instead of just the pad unlink events.
+                //
+                // Anyways, we can tell by the sink_pad appearing as a small value, such as 0x11, 0x21, etc.
+                if res == GTRUE && sink_pad as usize > 4096usize {
+                    // See if we have a cache for this pad pair. Sometimes unlink is called for the
+                    // src_pad, but the sink_pad is not a pad, its something else. I am not sure what.
+                    // Anyways, as a result, we confirm the sink_pad matches what we expect before
+                    // unlinking.
+                    let pad_cache = glib::gobject_ffi::g_object_get_qdata(
+                        src_pad as *mut gobject_sys::GObject,
+                        *PAD_CACHE_QUARK,
+                    ) as *mut PadCacheData;
+
+                    // If the peer matches the provided sink, we remove the cache.
+                    if !pad_cache.is_null() && sink_pad as *mut c_void == (*pad_cache).peer {
+                        gst::trace!(
+                            CAT,
+                            "removing cache for src_pad: {:?}, sink_pad: {:?}",
+                            src_pad,
+                            sink_pad
+                        );
+                        glib::gobject_ffi::g_object_set_qdata_full(
+                            src_pad as *mut gobject_sys::GObject,
+                            *PAD_CACHE_QUARK,
+                            std::ptr::null_mut(),
+                            None,
+                        );
+                    }
+                }
             }
 
             unsafe {
+                // Push hooks; majority of the time we are pushing.
                 ffi::gst_tracing_register_hook(
                     tracer_obj.to_glib_none().0,
                     c"pad-push-pre".as_ptr(),
@@ -155,6 +242,7 @@ mod imp {
                         do_push_buffer_post as *const (),
                     ),
                 );
+                // Pull hooks; far less common, but still useful.
                 ffi::gst_tracing_register_hook(
                     tracer_obj.to_glib_none().0,
                     c"pad-pull-range-pre".as_ptr(),
@@ -167,6 +255,21 @@ mod imp {
                     c"pad-pull-range-post".as_ptr(),
                     std::mem::transmute::<*const (), Option<unsafe extern "C" fn()>>(
                         do_pull_range_post as *const (),
+                    ),
+                );
+                // Link hooks; allow us to populate and clear the pads' quark cache.
+                ffi::gst_tracing_register_hook(
+                    tracer_obj.to_glib_none().0,
+                    c"do_pad_link_post".as_ptr(),
+                    std::mem::transmute::<*const (), Option<unsafe extern "C" fn()>>(
+                        do_pad_link_post as *const (),
+                    ),
+                );
+                ffi::gst_tracing_register_hook(
+                    tracer_obj.to_glib_none().0,
+                    c"do_pad_unlink_post".as_ptr(),
+                    std::mem::transmute::<*const (), Option<unsafe extern "C" fn()>>(
+                        do_pad_unlink_post as *const (),
                     ),
                 );
             }
@@ -205,7 +308,6 @@ mod imp {
 
     // Add this function, which is the handler for the "request-metrics" signal
     fn request_metrics() -> String {
-        gst::debug!(CAT, "Metrics requested via signal");
         let metric_families = gather();
         let mut buffer = Vec::new();
         let encoder = TextEncoder::new();
@@ -233,14 +335,20 @@ mod imp {
         })
     }
 
-    fn is_proxy_pad(pad: *mut ffi::GstPad) -> bool {
-        let proxy_pad_type = unsafe { ffi::gst_proxy_pad_get_type() };
-        unsafe {
-            glib::gobject_ffi::g_type_check_instance_is_a(
-                pad as *mut glib::gobject_ffi::GTypeInstance,
-                proxy_pad_type,
-            ) == glib::ffi::GTRUE
-        }
+    unsafe fn is_pad(pad: *mut ffi::GstPad) -> bool {
+        let pad_type = ffi::gst_pad_get_type();
+        glib::gobject_ffi::g_type_check_instance_is_a(
+            pad as *mut glib::gobject_ffi::GTypeInstance,
+            pad_type,
+        ) == glib::ffi::GTRUE
+    }
+
+    unsafe fn is_proxy_pad(pad: *mut ffi::GstPad) -> bool {
+        let proxy_pad_type = ffi::gst_proxy_pad_get_type();
+        glib::gobject_ffi::g_type_check_instance_is_a(
+            pad as *mut glib::gobject_ffi::GTypeInstance,
+            proxy_pad_type,
+        ) == glib::ffi::GTRUE
     }
 
     /// Given an optional `Pad`, returns the real parent `Element`, skipping over a `GhostPad` proxy.
@@ -268,15 +376,8 @@ mod imp {
             return o_pad;
         }
 
-        let proxy_pad_type = unsafe { ffi::gst_proxy_pad_get_type() };
-        let is_proxy_pad = unsafe {
-            glib::gobject_ffi::g_type_check_instance_is_a(
-                pad as *mut glib::gobject_ffi::GTypeInstance,
-                proxy_pad_type,
-            )
-        };
-
-        if is_proxy_pad == glib::ffi::GTRUE {
+        let is_a_proxy_pad = unsafe { is_proxy_pad(pad) };
+        if is_a_proxy_pad {
             let maybe_ghost_pad = unsafe {
                 ffi::gst_object_get_parent(pad as *mut ffi::GstObject) as *mut ffi::GstPad
             };
@@ -306,155 +407,256 @@ mod imp {
     unsafe extern "C" fn drop_value<QD>(ptr: *mut c_void) {
         debug_assert!(!ptr.is_null());
         let value: Box<QD> = Box::from_raw(ptr as *mut QD);
+
+        // Explicitly drop the value as I am still new to rust and this reminds
+        // me how it works.
         drop(value)
     }
-    unsafe fn do_send_latency_ts(
-        ts: u64,
-        src_pad: *mut gst::ffi::GstPad,
-        sink_pad: *mut gst::ffi::GstPad,
-    ) {
-        if !sink_pad.is_null()
-            && ffi::gst_pad_get_direction(sink_pad) == ffi::GST_PAD_SINK
-            && !is_proxy_pad(src_pad)
-        {
-            if let Some(parent) = get_real_pad_parent_ffi(sink_pad) {
-                if !parent.is_null()
-                    && glib::gobject_ffi::g_type_check_instance_is_a(
-                        parent as *mut gobject_sys::GTypeInstance,
-                        ffi::gst_bin_get_type(),
-                    ) == glib::ffi::GFALSE
-                {
-                    // To avoid many tiny allocations, if quark is present, we overwrite it
-                    let existing = glib::gobject_ffi::g_object_get_qdata(
-                        sink_pad as *mut gobject_sys::GObject,
-                        *LATENCY_QUARK,
-                    ) as *mut u64;
-                    if !existing.is_null() {
-                        // Overwrite in place:
-                        *existing = ts;
-                    } else {
-                        // First time: allocate & install
-                        let ptr = Box::into_raw(Box::new(ts)) as *mut c_void;
-                        glib::gobject_ffi::g_object_set_qdata_full(
-                            sink_pad as *mut gobject_sys::GObject,
-                            *LATENCY_QUARK,
-                            ptr,
-                            Some(drop_value::<u64>),
-                        );
-                    }
-                }
-            }
+    unsafe fn do_send_latency_ts(ts: u64, src_pad: *mut gst::ffi::GstPad) {
+        let pad_cache = unsafe {
+            glib::gobject_ffi::g_object_get_qdata(
+                src_pad as *mut gobject_sys::GObject,
+                *PAD_CACHE_QUARK,
+            ) as *mut PadCacheData
+        };
+        if pad_cache.is_null() {
+            return;
         }
+
+        // If we have a valid cache, we can safely convert the pointer to a Box.
+        let pad_cache: &mut PadCacheData = unsafe { &mut *pad_cache };
+
+        // Set the ts
+        pad_cache.ts = ts;
     }
 
-    unsafe fn do_receive_and_record_latency_ts(
-        ts: u64,
+    /// Given a source and sink pad, returns the PadCacheData for the pad pair.
+    /// If the pads are not valid for any reason, returns a sentinel value indicating to skip this pair.
+    ///
+    /// Background required to understand this function:
+    ///
+    /// Recall that pads can be arranged like any of the following patterns in gstreamer:
+    ///
+    /// Simple case:
+    ///
+    /// ```text
+    /// Elem_A → Elem_A.src → Elem_B.sink → Elem_B
+    /// ```
+    ///
+    /// Ghost pad case:
+    ///
+    /// ```text
+    /// Bin A { child: Elem_A.src → GhostPad { child: ProxyPad.src → } } → Elem_B (sink)
+    /// ```
+    ///
+    /// Nested case with multiple bins, leading to multiple ghost pads:
+    ///
+    /// ```text
+    /// Bin B { child: Bin A { child: Elem_A.src → GhostPad { child: ProxyPad.src → } → GhostPad { child: ProxyPad.src → } } } → Elem_B (sink)
+    /// ```
+    ///
+    /// While in common cases ghost pads are used to link elements across bins, they can also be used to wrap pads arbitrarily.
+    /// The examples above focus on the bin case as it is the most common in practice.
+    ///
+    /// We've been measuring latency spanning operations for given Element B by recording ts at prepush of the source pad of upstream
+    /// Element A, and then at the post push of Element A.
+    ///
+    /// However, when GhostPads and ProxyPads are involved, we need to ensure that we are measuring the latency across
+    /// the real pads, and not accidentally including time spent performing operations in the parent bin, which may be
+    /// the case if we measure the time between last src element of a bin to the first sink element outside the bin.
+    ///
+    /// For now this method omits the proxy pad case; however, later on we will measure latency spanning elements which
+    /// will better account for proxy pads and ghost pads, and capture the true latency across elements.
+    fn do_create_latency_cache_for_pad_pair(
         src_pad: *mut gst::ffi::GstPad,
         sink_pad: *mut gst::ffi::GstPad,
-    ) {
-        if !sink_pad.is_null()
-            && ffi::gst_pad_get_direction(sink_pad) == ffi::GST_PAD_SINK
-            && !is_proxy_pad(src_pad)
-        {
-            if let Some(parent) = get_real_pad_parent_ffi(sink_pad) {
-                if !parent.is_null()
-                    && glib::gobject_ffi::g_type_check_instance_is_a(
-                        parent as *mut gobject_sys::GTypeInstance,
-                        ffi::gst_bin_get_type(),
-                    ) == glib::ffi::GFALSE
-                {
-                    // Get the the qdata; this means drop_value will not be called
-                    // and we can safely convert the pointer to a Box.
-                    let src_ts = glib::gobject_ffi::g_object_get_qdata(
-                        sink_pad as *mut gobject_sys::GObject,
-                        *LATENCY_QUARK,
-                    ) as *mut u64;
-                    if !src_ts.is_null() && *src_ts != 0 {
-                        log_latency_ffi(*src_ts, sink_pad, ts, parent);
-                        // Reset the value to avoid reusing it
-                        *src_ts = 0;
-                    }
-                }
-            }
-        }
-    }
-
-    unsafe fn log_latency_ffi(
-        src_ts: u64,
-        sink_pad: *mut gst::ffi::GstPad,
-        sink_ts: u64,
-        _parent: *mut gst::ffi::GstElement,
-    ) {
-        // ffi version which is intended to be faster
-        let src_pad = ffi::gst_pad_get_peer(sink_pad);
-        let diff = sink_ts.saturating_sub(src_ts);
-
-        // I am not sure how unsafe this is, but we do it anyways
-        let key = src_pad as usize + sink_pad as usize;
-
-        // Insert if absent, then get a reference
-        let metrics = METRIC_CACHE.entry(key).or_insert_with(|| {
-            // Get the real sink pad
-            let binding = get_real_pad_ffi(sink_pad).unwrap();
-            let sink_pad_s = gst::Pad::from_glib_ptr_borrow(&binding);
-            // Get the real src pad
-            let binding = get_real_pad_ffi(src_pad).unwrap();
-            let src_pad_s = gst::Pad::from_glib_ptr_borrow(&binding);
-            let element_latency = get_real_pad_parent_ffi(sink_pad).unwrap();
-
-            let sink_name = sink_pad_s.name().to_string();
-            let element_latency_name = if !element_latency.is_null() {
-                let element_latency_s = gst::Element::from_glib_ptr_borrow(&element_latency);
-                // If we have a parent element, use its name
-                element_latency_s.name().to_string()
-            } else {
-                // Otherwise, use the pad name directly
-                sink_name.clone()
-            };
-
-            // back to string for now
-            let sink_pad_name = if !element_latency.is_null() {
-                // el.name + "." + sink_pad.name()
-                element_latency_name.clone() + "." + &sink_name
-            } else {
-                sink_name.clone()
-            };
-
-            // do the same for the source pad
-            let src_pad_name = if !src_pad.is_null() {
-                let parent = get_real_pad_parent_ffi(src_pad).unwrap();
-                if !parent.is_null() {
-                    let element_src = gst::Element::from_glib_ptr_borrow(&parent);
-                    // If we have a parent element, use its name
-                    element_src.name().to_string() + "." + &src_pad_s.name()
-                } else {
-                    // Otherwise, just use the pad name
-                    src_pad_s.name().to_string()
-                }
-            } else {
-                "unknown_src_pad".into()
-            };
-
-            let labels = &[&element_latency_name, &src_pad_name, &sink_pad_name];
-            gst::info!(
+    ) -> *mut PadCacheData {
+        // Ensure pads are not null.
+        if src_pad.is_null() || sink_pad.is_null() {
+            gst::trace!(
                 CAT,
-                "Logging latency for element: {}, src_pad: {}, sink_pad: {}",
-                element_latency_name,
-                src_pad_name,
-                sink_pad_name
+                "do_get_latency_cache_for_pad_pair called with null pads: src: {:?}, sink: {:?}",
+                src_pad,
+                sink_pad
             );
-            (
-                LATENCY_LAST.with_label_values(labels),
-                LATENCY_SUM.with_label_values(labels),
-                LATENCY_COUNT.with_label_values(labels),
-            )
-        });
+            return PAD_SKIP_SENTINEL as *mut PadCacheData;
+        }
 
-        // metrics is a &mut (Gauge, Counter, Counter)
-        let (last_g, sum_c, cnt_c) = metrics.value();
-        last_g.set(diff as f64);
-        sum_c.inc_by(diff as f64);
-        cnt_c.inc();
+        // Ensure what we were passed are actually pads
+        if !unsafe { is_pad(src_pad) } || !unsafe { is_pad(sink_pad) } {
+            gst::trace!(
+                CAT,
+                "do_get_latency_cache_for_pad_pair called with non-pad objects: src: {:?}, sink: {:?}",
+                src_pad,
+                sink_pad
+            );
+            return PAD_SKIP_SENTINEL as *mut PadCacheData;
+        }
+
+        // Check if they are the direction we expect.
+        if unsafe { ffi::gst_pad_get_direction(sink_pad) } != ffi::GST_PAD_SINK
+            || unsafe { ffi::gst_pad_get_direction(src_pad) } != ffi::GST_PAD_SRC
+        {
+            gst::trace!(
+                CAT,
+                "do_get_latency_cache_for_pad_pair called with invalid pads: src: {:?}, sink: {:?}",
+                src_pad,
+                sink_pad
+            );
+            return PAD_SKIP_SENTINEL as *mut PadCacheData;
+        }
+
+        // Get the real parent of the sink pad, which is what we are measuring across.
+        let parent = get_real_pad_parent_ffi(sink_pad);
+        if parent.is_none() {
+            unsafe {
+                gst::trace!(
+                    CAT,
+                    "do_get_latency_cache_for_pad_pair called on {}.{} {}.{}, but no real parent found.",
+                    gst::Pad::from_glib_ptr_borrow(&src_pad)
+                        .parent()
+                        .map(|p| p.name())
+                        .unwrap_or("unknown".into()),
+                    gst::Pad::from_glib_ptr_borrow(&src_pad).name(),
+                    gst::Pad::from_glib_ptr_borrow(&sink_pad)
+                        .parent()
+                        .map(|p| p.name())
+                        .unwrap_or("unknown".into()),
+                    gst::Pad::from_glib_ptr_borrow(&sink_pad).name()
+                );
+            }
+            // If we don't have a parent, we can't measure latency.
+            return PAD_SKIP_SENTINEL as *mut PadCacheData;
+        }
+
+        // Ensure the parent is not a bin, as we currently do not support measuring latency across bins.
+        if unsafe {
+            glib::gobject_ffi::g_type_check_instance_is_a(
+                parent.unwrap() as *mut gobject_sys::GTypeInstance,
+                ffi::gst_bin_get_type(),
+            ) == glib::ffi::GTRUE
+        } {
+            // If the parent is a bin, we cannot measure latency across it.
+            return PAD_SKIP_SENTINEL as *mut PadCacheData;
+        }
+
+        // Here's where things get a bit weird. In the push case, if our src pad is a proxy pad,
+        // we skip, because measuring latency across the proxy pad, while accurate, results in double counting;
+        // once for the proxy pad to the sink, and once for the src pad to the ghost pad.
+        //
+        // While we would like to omit the ghost pad case, as measuring latency across the ghost pad may include parts
+        // of the parent bins processing time, the ghost pad is likely not linked yet and thus we cannot retrieve it.
+
+        if unsafe { is_proxy_pad(src_pad) } {
+            // If the src pad is a proxy pad, we choose to measure latency from ghost pad to sink pad.
+            return PAD_SKIP_SENTINEL as *mut PadCacheData;
+        }
+
+        // Create & return the cache.
+        Box::<PadCacheData>::into_raw(Box::new(create_pad_cache_data(src_pad, sink_pad)))
+    }
+
+    fn create_pad_cache_data(
+        src_pad: *mut gst::ffi::GstPad,
+        sink_pad: *mut gst::ffi::GstPad,
+    ) -> PadCacheData {
+        // Our ts is 0, representing we have not had a valid push yet.
+        let ts = 0;
+
+        // Get the 'real' sink pad (non-ghost, non-proxy)
+        let binding = get_real_pad_ffi(sink_pad).unwrap();
+        let sink_pad_s = unsafe { gst::Pad::from_glib_ptr_borrow(&binding) };
+
+        // Get the 'real' src pad (non-ghost, non-proxy)
+        let binding = get_real_pad_ffi(src_pad).unwrap();
+        let src_pad_s = unsafe { gst::Pad::from_glib_ptr_borrow(&binding) };
+
+        // Get the parent of the sink, what we're measuring across.
+        let sink_element_parent = get_real_pad_parent_ffi(sink_pad).unwrap();
+
+        let sink_name = sink_pad_s.name().to_string();
+        let element_latency_name = if !sink_element_parent.is_null() {
+            let element_latency_s =
+                unsafe { gst::Element::from_glib_ptr_borrow(&sink_element_parent) };
+            // If we have a parent element, use its name
+            element_latency_s.name().to_string()
+        } else {
+            // Otherwise, use the pad name directly
+            sink_name.clone()
+        };
+        let sink_pad_name = if !sink_element_parent.is_null() {
+            // el.name + "." + sink_pad.name()
+            element_latency_name.clone() + "." + &sink_name
+        } else {
+            sink_name.clone()
+        };
+
+        // do the same for the source pad
+        let src_pad_name = if !src_pad.is_null() {
+            let parent = get_real_pad_parent_ffi(src_pad).unwrap();
+            if !parent.is_null() {
+                let element_src = unsafe { gst::Element::from_glib_ptr_borrow(&parent) };
+                // If we have a parent element, use its name
+                element_src.name().to_string() + "." + &src_pad_s.name()
+            } else {
+                // Otherwise, just use the pad name
+                src_pad_s.name().to_string()
+            }
+        } else {
+            "unknown_src_pad".into()
+        };
+
+        let labels = &[&element_latency_name, &src_pad_name, &sink_pad_name];
+        gst::info!(
+            CAT,
+            "Registering latency for element: {}, src_pad: {} ({:?}), sink_pad: {} ({:?})",
+            element_latency_name,
+            src_pad_name,
+            src_pad,
+            sink_pad_name,
+            sink_pad
+        );
+
+        let last_gauge = LATENCY_LAST.with_label_values(labels);
+        let sum_counter = LATENCY_SUM.with_label_values(labels);
+        let count_counter = LATENCY_COUNT.with_label_values(labels);
+
+        PadCacheData {
+            ts,
+            peer: sink_pad as *mut c_void,
+            last_gauge,
+            sum_counter,
+            count_counter,
+        }
+    }
+
+    unsafe fn do_receive_and_record_latency_ts(ts: u64, src_pad: *mut gst::ffi::GstPad) {
+        let pad_cache = unsafe {
+            glib::gobject_ffi::g_object_get_qdata(
+                src_pad as *mut gobject_sys::GObject,
+                *PAD_CACHE_QUARK,
+            ) as *mut PadCacheData
+        };
+        if pad_cache.is_null() {
+            return;
+        }
+
+        // If we have a valid cache, we can safely convert the pointer to a Box.
+        let pad_cache: &mut PadCacheData = unsafe { &mut *pad_cache };
+
+        // If the ts is 0, we skip, as we have not had a valid push yet.
+        if pad_cache.ts == 0 {
+            return;
+        }
+        // Calculate the difference
+        let diff = ts.saturating_sub(pad_cache.ts);
+
+        // Log the latency
+        pad_cache
+            .last_gauge
+            .set(diff.try_into().unwrap_or(i64::MAX));
+        pad_cache.sum_counter.inc_by(diff);
+        pad_cache.count_counter.inc();
     }
 
     /// If the env var is set and valid, spawn the HTTP server in a new thread.

--- a/tracer/prometheus/tests/promlatency.rs
+++ b/tracer/prometheus/tests/promlatency.rs
@@ -393,7 +393,7 @@ mod tests {
     }
 
     fn create_pipeline(name: &str) -> gst::Pipeline {
-        let pipeline_el = gst::parse::launch("fakesrc num-buffers=100000 ! identity ! fakesink")
+        let pipeline_el = gst::parse::launch("fakesrc num-buffers=10000 ! identity ! fakesink")
             .expect("Failed to create pipeline from launch string");
         pipeline_el.set_property("name", name);
 


### PR DESCRIPTION
# Description

Reduce the overhead and improve the speed of prom-latency by pre-caching all information required to register metrics quickly. Essentially is a single pointer lookup & then atomic increments, plus an assignment of a ts.

## Changes

- reimplemented prom-latency in such a way that would be fast
- updated README.md to let people know this work is still pretty experimental
- added a 'profiling' profile to ensure we are looking at an instruction optimized version

## Future work

- Adjust implementation to measure element latency across elements rather than cumsum of next elements
- Port performance improvements to otel implementation

## How Has This Been Tested?

I ran the tests and the benchmarks. I don't know how to read the benchmarks properly yet, but there's no way this isn't significantly faster.