### PR TITLE
impl: per element latency tracing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,20 @@ A rust reimagination of [gstlatency.c](https://gitlab.freedesktop.org/gstreamer/
 
 The table below contains the plugins available in this repository.
 
-| plugin name  | description                                                                                                               | performance  | stability |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------ | --------- |
-| prom-latency | captures per element latencies as prometheus metrics                                                                      | optimized    | alpha     |
-| otel-tracer  | captures per element latencies as otel traces, gst::logs as otel logs, and otel-compatiable metrics with full association | very slow    | pre-alpha |
-| noop-latency | a test plugin, likely not useful for any real purpose                                                                     | slow         | none      |
+| plugin name  | description                                                                                                               | performance | stability |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ----------- | --------- |
+| prom-latency | captures per element latencies as prometheus metrics                                                                      | optimized   | alpha     |
+| otel-tracer  | captures per element latencies as otel traces, gst::logs as otel logs, and otel-compatiable metrics with full association | very slow   | pre-alpha |
+| noop-latency | a test plugin, likely not useful for any real purpose                                                                     | slow        | none      |
 
-> Currently, the way per element latency is calculated is confusing in that it captures all
-> latency between the measured element and the next thread boundary, such as a queue, or a sink element.
+In general `prom-latency` is recommended for now, and `otel-tracer` is still a work in progress.
+
+> Currently, the way per element latency is calculated using the `prom-latency` element does not cleanly handle
+> thread-boundaries introduced by the `threadshare` plugin. However, it should work fine for most pipelines that do not
+> use actix powered elements.
 >
-> A future change will address this issue to capture latency across the element in question only, but for now
-> prom-latency and otel-tracer serve more as a POC that this is possible.
+> A future change will address this issue to more precisely measure latency across elements even in the presence of
+> async runtime elements.
 
 ## Setup
 


### PR DESCRIPTION
Fix a known issue where per element latency tracing doesn't span elements.

While this solution of using threadlocals is not be perfect, it does cover the majority of the cases quite well with minimal changes & little performance overhead.