### PR TITLE
Handle unknown GStreamer debug levels

### DIFF
--- a/tracer/otel/src/otellogbridge.rs
+++ b/tracer/otel/src/otellogbridge.rs
@@ -58,7 +58,10 @@ fn severity_of_debug_level(level: DebugLevel) -> Severity {
         DebugLevel::Debug => Severity::Debug,
         DebugLevel::Trace => Severity::Trace,
         DebugLevel::Memdump => Severity::Trace,
-        _ => todo!(),
+        // Future versions of GStreamer might introduce additional debug levels.
+        // Instead of panicking on unrecognized values, map them to `Severity::Debug`
+        // so that log processing continues gracefully.
+        DebugLevel::__Unknown(_) => Severity::Debug,
     }
 }
 


### PR DESCRIPTION
## Summary
- Avoid panic when new or unknown GStreamer debug levels are encountered

## Testing
- `cargo test` *(fails: system library `glib-2.0` required by crate `glib-sys` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894c113a818832497230b0945261b27