### PR TITLE
feat(prom-latency): track buffer list pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cargo test
 - [ ] In `prom-latency` split count metric into `buf_in_count` and `buf_out_count` to capture behavior of muxer & demuxer elements.
 - [ ] In `prom-latency`, add better support latency measurements for elements and bins with multiple sink and src pads.
 - [ ] In `prom-latency`, reimplement `pad_pull_pre` and `pad_pull_post` hooks to capture latency (unsure exactly how this will look at this point).
-- [ ] In `prom-latency`, implement `pad_push_list_pre` and `pad_pus_list_post` hooks to capture latency.
+- [x] In `prom-latency`, implement `pad_push_list_pre` and `pad_pus_list_post` hooks to capture latency.
 - [ ] In `otel-tracer`, port performance & implementation improvements made to `prom-latency` such that `otel-tracer` can be used in production with similarly low overhead.
 - [ ] `otel-tracer` to collect metrics with trace and span data included in exemplars.
 - [ ] In `pyroscope`, determine how to get debug symbols for all of gstreamers dependencies.

--- a/tracer/prometheus/src/promlatency.rs
+++ b/tracer/prometheus/src/promlatency.rs
@@ -144,6 +144,23 @@ mod imp {
                 do_receive_and_record_latency_ts(ts, pad);
             }
 
+            unsafe extern "C" fn do_push_list_pre(
+                _tracer: *mut gst::Tracer,
+                ts: u64,
+                pad: *mut gst::ffi::GstPad,
+                _list_ptr: *mut gst::ffi::GstBufferList,
+            ) {
+                do_send_latency_ts(ts, pad);
+            }
+
+            unsafe extern "C" fn do_push_list_post(
+                _tracer: *mut gst::Tracer,
+                ts: u64,
+                pad: *mut gst::ffi::GstPad,
+            ) {
+                do_receive_and_record_latency_ts(ts, pad);
+            }
+
             unsafe extern "C" fn do_pull_range_pre(
                 _tracer: *mut gst::Tracer,
                 _ts: u64,
@@ -247,6 +264,20 @@ mod imp {
                     c"pad-push-post".as_ptr(),
                     std::mem::transmute::<*const (), Option<unsafe extern "C" fn()>>(
                         do_push_buffer_post as *const (),
+                    ),
+                );
+                ffi::gst_tracing_register_hook(
+                    tracer_obj.to_glib_none().0,
+                    c"pad-push-list-pre".as_ptr(),
+                    std::mem::transmute::<*const (), Option<unsafe extern "C" fn()>>(
+                        do_push_list_pre as *const (),
+                    ),
+                );
+                ffi::gst_tracing_register_hook(
+                    tracer_obj.to_glib_none().0,
+                    c"pad-push-list-post".as_ptr(),
+                    std::mem::transmute::<*const (), Option<unsafe extern "C" fn()>>(
+                        do_push_list_post as *const (),
                     ),
                 );
                 // Pull hooks; far less common, but still useful.


### PR DESCRIPTION
## Summary
- capture latency for GstBufferLists by hooking pad-push-list events
- document completion of pad_push_list hooks in README

## Testing
- `cargo build -p gst-prometheus-tracer`
- `cargo test -p gst-prometheus-tracer` *(fails: tests::given_pipeline_with_known_latency_when_run_then_latency_metrics_match)*
- `~/.cargo/bin/just lint`


------
https://chatgpt.com/codex/tasks/task_b_6894f073d368832489487b10c623d48f