### PR TITLE
chore: use prebuilt ci image

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,43 +8,9 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ github.repository_owner }}/gst-tracer-otel-ci:latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - uses: extractions/setup-just@v3
-        with:
-          just-version: 1.40.0
-      - name: Install build dependencies
-        run: |
-          sudo .devcontainer/setup-root.sh
-          .devcontainer/setup-user.sh
-      # ────────────────────────────────────────────────
-      # Cache Cargo registry + build artefacts
-      # ────────────────────────────────────────────────
-      - name: Cache APT packages (GStreamer)
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.devcontainer/setup-root.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-
-
-      - name: Cache User binaries (act)
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/bin
-          key: ${{ runner.os }}-user-bin-${{ hashFiles('.devcontainer/setup-user.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-user-bin-
-
-      - name: Cache Cargo-installed binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/
-          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('.devcontainer/setup-user.sh') }}
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -61,6 +27,7 @@ jobs:
           key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-release
           restore-keys: |
             ${{ runner.os }}-cargo-target-
+
       - name: Run audit
         run: just audit
       - name: Run clippy

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,27 @@
+name: Build CI Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/gst-tracer-otel-ci:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   bench-update:
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ github.repository_owner }}/gst-tracer-otel-ci:latest
     steps:
       # 1. Check out the full history so we can commit back
       - name: Checkout
@@ -15,37 +16,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 2. Install just
-      - name: Setup just
-        uses: extractions/setup-just@v3
-        with:
-          just-version: "1.40.0"
-
       # ────────────────────────────────────────────────
       # Cache Cargo registry + build artefacts
       # ────────────────────────────────────────────────
-      - name: Cache APT packages (GStreamer)
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.devcontainer/setup-root.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-
-
-      - name: Cache User binaries (act)
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/bin
-          key: ${{ runner.os }}-user-bin-${{ hashFiles('.devcontainer/setup-user.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-user-bin-
-
-      - name: Cache Cargo-installed binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/
-          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('.devcontainer/setup-user.sh') }}
-
       - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
@@ -61,12 +34,6 @@ jobs:
           key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-release
           restore-keys: |
             ${{ runner.os }}-cargo-target-
-
-      # 5. Install dependencies
-      - name: Install build dependencies
-        run: |
-          sudo .devcontainer/setup-root.sh
-          .devcontainer/setup-user.sh
 
       # 6. Run the benchmark update
       - name: Run bench-perf-update

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,47 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ github.repository_owner }}/gst-tracer-otel-ci:latest
     steps:
-      # ────────────────────────────────────────────────
-      # Check out repo
-      # ────────────────────────────────────────────────
       - uses: actions/checkout@v4
-
-      # ────────────────────────────────────────────────
-      # Rust toolchain & GStreamer + gdb
-      # ────────────────────────────────────────────────
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: extractions/setup-just@v3
-        with:
-          just-version: 1.40.0
-      # ────────────────────────────────────────────────
-      # Cache Cargo registry + build artefacts
-      # ────────────────────────────────────────────────
-      - name: Cache APT packages (GStreamer)
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.devcontainer/setup-root.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-
-
-      - name: Cache User binaries (act)
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/bin
-          key: ${{ runner.os }}-user-bin-${{ hashFiles('.devcontainer/setup-user.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-user-bin-
-
-      - name: Cache Cargo-installed binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/
-          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('.devcontainer/setup-user.sh') }}
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -66,32 +28,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-target-
 
-      - name: Install build dependencies
-        run: |
-          sudo .devcontainer/setup-root.sh
-          .devcontainer/setup-user.sh
-
-      # ────────────────────────────────────────────────
-      # Build plug-in (release w/ debuginfo)
-      # ────────────────────────────────────────────────
       - name: Cargo build (release)
         run: just build
 
-      # ────────────────────────────────────────────────
-      # Cargo test
-      # ────────────────────────────────────────────────
       - name: Cargo test
         run: just test
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: llvm-tools-preview
 
-      # ────────────────────────────────────────────────
-      #  Run tests with address sanitizer to look for
-      #    memory leaks
-      # ────────────────────────────────────────────────
       - name: Run tests with address sanitizer
-        run: |
-          just test-address-sanitizer
+        run: just test-address-sanitizer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-lc"]
+
+ARG USERNAME=ubuntu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create a non-root user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+# Install git and docker then clean up
+RUN apt-get update \
+    && apt-get install -y git docker.io \
+    && rm -rf /var/lib/apt/lists/* \
+    && usermod -aG docker $USERNAME
+
+# Install dependencies requiring root
+COPY .devcontainer/setup-root.sh /tmp/setup-root.sh
+RUN bash /tmp/setup-root.sh
+
+# Switch to the non-root user
+USER $USERNAME
+WORKDIR /home/$USERNAME
+ENV HOME=/home/$USERNAME
+ENV USER=$USERNAME
+ENV PATH="/home/$USERNAME/.cargo/bin:/home/$USERNAME/bin:$PATH"
+
+# Install user-level dependencies and nightly component
+COPY .devcontainer/setup-user.sh /tmp/setup-user.sh
+RUN GITHUB_ACTIONS=true bash /tmp/setup-user.sh \
+    && rustup component add llvm-tools-preview --toolchain nightly
+


### PR DESCRIPTION
## Summary
- build reusable Docker image for CI with project setup scripts
- publish the image to GHCR via manual workflow
- run CI workflows inside the prebuilt image instead of installing deps

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p gst-noop-tracer`
- `cargo test -p gst-otel-tracer`
- `cargo test -p gst-prometheus-tracer` *(failed: test promlatency)*
- `cargo test -p gst-pyroscope-tracer`

------
https://chatgpt.com/codex/tasks/task_b_6895073d871c8324a8573779062180e3