### PR TITLE
impl(prometheus): add histogram metric sampling via env var

### DIFF
--- a/tracer/prometheus/README.md
+++ b/tracer/prometheus/README.md
@@ -63,6 +63,19 @@ The plugin will spawn an HTTP server on `0.0.0.0:9092`. To retrieve metrics:
 curl http://localhost:9092
 ```
 
+### Histogram Sampling
+
+Histogram observation can be sampled using:
+
+```bash
+export GST_PROM_LATENCY_HISTOGRAM_SAMPLE_RATE=1000
+```
+
+- `1` (default): observe every latency in the histogram.
+- `N > 1`: observe every `N`th latency in the histogram.
+- This sampling only affects histogram buckets/sum/count for `gst_element_latency_seconds_histogram`.
+- `gst_element_latency_last_gauge`, `gst_element_latency_sum_count`, and `gst_element_latency_count_count` are always recorded for every latency event.
+
 ### Example Output
 
 ```plaintext
@@ -78,6 +91,12 @@ gstreamer_element_latency_last_gauge{element="identity0",sink_pad="identity0.sin
 # TYPE gstreamer_element_latency_sum_count counter
 gstreamer_element_latency_sum_count{element="fakesink0",sink_pad="fakesink0.sink",src_pad="identity0.src"} 3036567246
 gstreamer_element_latency_sum_count{element="identity0",sink_pad="identity0.sink",src_pad="fakesrc0.src"} 7819315483
+# HELP gst_element_latency_seconds_histogram Latency histogram in seconds per element
+# TYPE gst_element_latency_seconds_histogram histogram
+gst_element_latency_seconds_histogram_bucket{element="identity0",path="/pipeline0",sink_pad="identity0.sink",src_pad="fakesrc0.src",le="0.01"} 591573
+gst_element_latency_seconds_histogram_bucket{element="identity0",path="/pipeline0",sink_pad="identity0.sink",src_pad="fakesrc0.src",le="0.025"} 591573
+gst_element_latency_seconds_histogram_sum{element="identity0",path="/pipeline0",sink_pad="identity0.sink",src_pad="fakesrc0.src"} 7.819315483
+gst_element_latency_seconds_histogram_count{element="identity0",path="/pipeline0",sink_pad="identity0.sink",src_pad="fakesrc0.src"} 591573
 ```
 
 ## Collecting Metrics via the `metrics` Signal

--- a/tracer/prometheus/src/promlatencyimp.rs
+++ b/tracer/prometheus/src/promlatencyimp.rs
@@ -50,8 +50,8 @@ static LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
         "Latency histogram in seconds per element",
         &["element", "src_pad", "sink_pad", "path"],
         vec![
-            0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0,
-            10.0, 15.0, 30.0, 60.0,
+            0.00001, 0.0001, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75,
+            1.0, 2.5, 5.0, 10.0, 20.0, 60.0, 240.0,
         ]
     )
     .unwrap()

--- a/tracer/prometheus/src/promlatencyimp.rs
+++ b/tracer/prometheus/src/promlatencyimp.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::Cell,
+    env,
     os::raw::c_void,
     sync::{LazyLock, OnceLock},
     thread,
@@ -13,8 +14,8 @@ use glib::{
 use gst::{ffi, prelude::*};
 use gstreamer as gst;
 use prometheus::{
-    gather, register_int_counter_vec, register_int_gauge_vec, Encoder, IntCounter, IntCounterVec,
-    IntGauge, IntGaugeVec, TextEncoder,
+    gather, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Encoder,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, TextEncoder,
 };
 use tiny_http::{Header, Response, Server};
 
@@ -42,6 +43,25 @@ static LATENCY_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         &["element", "src_pad", "sink_pad", "path"]
     )
     .unwrap()
+});
+static LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        "gst_element_latency_seconds_histogram",
+        "Latency histogram in seconds per element",
+        &["element", "src_pad", "sink_pad", "path"],
+        vec![
+            0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0,
+            10.0, 15.0, 30.0, 60.0,
+        ]
+    )
+    .unwrap()
+});
+static HISTOGRAM_SAMPLE_RATE: LazyLock<u64> = LazyLock::new(|| {
+    env::var("GST_PROM_LATENCY_HISTOGRAM_SAMPLE_RATE")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(1)
 });
 
 thread_local! {
@@ -81,6 +101,8 @@ struct PadCacheData {
     // TODO - at the moment we don't differentiate between buffers into the element vs buffers out, will require
     //          a change to what we are doing here to make that work.
     count_counter: IntCounter,
+    histogram: Histogram,
+    histogram_observe_counter: u64,
 }
 
 #[derive(Default)]
@@ -462,6 +484,7 @@ impl PromLatencyTracerImp {
         let last_gauge = LATENCY_LAST.with_label_values(&labels);
         let sum_counter = LATENCY_SUM.with_label_values(&labels);
         let count_counter = LATENCY_COUNT.with_label_values(&labels);
+        let histogram = LATENCY_HISTOGRAM.with_label_values(&labels);
 
         // Create cache
         Box::into_raw(Box::new(PadCacheData {
@@ -470,6 +493,8 @@ impl PromLatencyTracerImp {
             last_gauge,
             sum_counter,
             count_counter,
+            histogram,
+            histogram_observe_counter: 0,
         }))
     }
 
@@ -543,6 +568,15 @@ impl PromLatencyTracerImp {
             .set(el_diff.try_into().unwrap_or(i64::MAX));
         pad_cache.sum_counter.inc_by(el_diff);
         pad_cache.count_counter.inc();
+        pad_cache.histogram_observe_counter = pad_cache.histogram_observe_counter.wrapping_add(1);
+        if pad_cache
+            .histogram_observe_counter
+            .is_multiple_of(*HISTOGRAM_SAMPLE_RATE)
+        {
+            pad_cache
+                .histogram
+                .observe(el_diff as f64 / 1_000_000_000f64);
+        }
 
         // Reset the timestamp for the next push
         pad_cache.ts = 0;

--- a/tracer/prometheus/tests/promlatency.rs
+++ b/tracer/prometheus/tests/promlatency.rs
@@ -96,6 +96,7 @@ mod tests {
             "gst_element_latency_last_gauge",
             "gst_element_latency_sum_count",
             "gst_element_latency_count_count",
+            "gst_element_latency_seconds_histogram",
         ];
         for metric in metric_asserts {
             assert!(
@@ -190,6 +191,7 @@ mod tests {
             "gst_element_latency_last_gauge",
             "gst_element_latency_sum_count",
             "gst_element_latency_count_count",
+            "gst_element_latency_seconds_histogram",
         ];
         for metric in metric_asserts {
             assert!(
@@ -579,19 +581,19 @@ mod tests {
         env::set_var("GST_TRACERS", "prom-latency(port=9999)");
         env::set_var("GST_DEBUG", "GST_TRACER:5,prom-latency:7");
         let root_manifest_dir = manifest_dir.parent().unwrap().parent().unwrap();
-        let plugin_targets = [("debug", true), ("debug", false)];
-        let plugin_paths = plugin_targets.iter().map(|(profile, with_target)| {
+        let plugin_profiles = ["debug", "profiling", "release", "test"];
+        let mut plugin_paths = Vec::new();
+        for profile in plugin_profiles {
             let base = root_manifest_dir.join(format!("target/{}", profile));
-            if *with_target {
+            plugin_paths.push(base.to_str().unwrap().to_owned());
+            plugin_paths.push(
                 base.join(format!("{ARCH}-unknown-linux-gnu"))
                     .to_str()
                     .unwrap()
-                    .to_owned()
-            } else {
-                base.to_str().unwrap().to_owned()
-            }
-        });
-        let gst_plugin_path = plugin_paths.collect::<Vec<_>>().join(":");
+                    .to_owned(),
+            );
+        }
+        let gst_plugin_path = plugin_paths.join(":");
         env::set_var("GST_PLUGIN_PATH", gst_plugin_path);
 
         // Initialize GStreamer
@@ -606,7 +608,7 @@ mod tests {
         );
 
         let binding = gst::active_tracers();
-        let tracer = binding
+        let _tracer = binding
             .iter()
             .find(|t| t.name() == "promlatencytracer0")
             .expect("Expected to find the `promlatencytracer0` tracer");


### PR DESCRIPTION
## Description

While average latency is useful, we typically care more about sniffing out tail latencies when it comes to media processing.

Add histogram metrics to enable capturing tail latency.

## How Has This Been Tested?

Tested against old implementation using the identity. It's a bit slower, (6%) but I did not record the results. So you will have to take my word on it this time.